### PR TITLE
chore: transfer this repository from suzuki-shunsuke to tfmigrator org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # tfmigrator
 
-[![Build Status](https://github.com/suzuki-shunsuke/tfmigrator/workflows/test/badge.svg)](https://github.com/suzuki-shunsuke/tfmigrator/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/suzuki-shunsuke/tfmigrator)](https://goreportcard.com/report/github.com/suzuki-shunsuke/tfmigrator)
-[![GitHub last commit](https://img.shields.io/github/last-commit/suzuki-shunsuke/tfmigrator.svg)](https://github.com/suzuki-shunsuke/tfmigrator)
-[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/tfmigrator/main/LICENSE)
+[![Build Status](https://github.com/tfmigrator/tfmigrator/workflows/test/badge.svg)](https://github.com/tfmigrator/tfmigrator/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tfmigrator/tfmigrator)](https://goreportcard.com/report/github.com/tfmigrator/tfmigrator)
+[![GitHub last commit](https://img.shields.io/github/last-commit/tfmigrator/tfmigrator.svg)](https://github.com/tfmigrator/tfmigrator)
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/tfmigrator/tfmigrator/main/LICENSE)
 
 Go library to migrate Terraform Configuration and State with `terraform state mv` and `terraform state rm` command and [hcledit](https://github.com/minamijoyo/hcledit).
 
@@ -28,10 +28,10 @@ But when we migrate many resources, it is hard to write YAML.
 So we started to develop tfmigrator as Go package instead of tfmigrator-cli.
 
 tfmigrator is Go package, so we can implement the migration rules with Go.
-In tfmigrator, we can migrate Terraform Configuration and State by implementing the interface [Planner](https://pkg.go.dev/github.com/suzuki-shunsuke/tfmigrator/tfmigrator#Planner).
+In tfmigrator, we can migrate Terraform Configuration and State by implementing the interface [Planner](https://pkg.go.dev/github.com/tfmigrator/tfmigrator/tfmigrator#Planner).
 This is very simple and powerful and flexible.
 And we don't have to learn the configuration file format and expr's Language specification, so the learning cost is low.
-Using [QuickRun](https://pkg.go.dev/github.com/suzuki-shunsuke/tfmigrator/tfmigrator#QuickRun) function, we can implement CLI for migration quickly.
+Using [QuickRun](https://pkg.go.dev/github.com/tfmigrator/tfmigrator/tfmigrator#QuickRun) function, we can implement CLI for migration quickly.
 
 And compared with tfmigrator-cli v1.0.0, tfmigrator provides rich feature.
 

--- a/examples/example1/main.go
+++ b/examples/example1/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator"
+	"github.com/tfmigrator/tfmigrator/tfmigrator"
 )
 
 func main() {

--- a/examples/example2/main.go
+++ b/examples/example2/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator"
+	"github.com/tfmigrator/tfmigrator/tfmigrator"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/suzuki-shunsuke/tfmigrator
+module github.com/tfmigrator/tfmigrator
 
 go 1.16
 

--- a/tfmigrator/hcledit/client.go
+++ b/tfmigrator/hcledit/client.go
@@ -3,7 +3,7 @@ package hcledit
 import (
 	"io"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/log"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/log"
 )
 
 // Client is a client to operate Terraform Configuration files with hcledit.

--- a/tfmigrator/migrate.go
+++ b/tfmigrator/migrate.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/hcledit"
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/tfstate"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/hcledit"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/tfstate"
 )
 
 // Migrate migrates Terraform Configuration and State with `terraform state mv` and `hcledit`.

--- a/tfmigrator/quick_run.go
+++ b/tfmigrator/quick_run.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	tflog "github.com/suzuki-shunsuke/tfmigrator/tfmigrator/log"
+	tflog "github.com/tfmigrator/tfmigrator/tfmigrator/log"
 )
 
 // QuickRun provides CLI interface to run tfmigrator quickly.

--- a/tfmigrator/runner.go
+++ b/tfmigrator/runner.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/hcledit"
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/log"
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/tfstate"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/hcledit"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/log"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/tfstate"
 )
 
 // Runner provides high level API to migrate Terraform Configuration and State.

--- a/tfmigrator/source.go
+++ b/tfmigrator/source.go
@@ -1,6 +1,6 @@
 package tfmigrator
 
-import "github.com/suzuki-shunsuke/tfmigrator/tfmigrator/tfstate"
+import "github.com/tfmigrator/tfmigrator/tfmigrator/tfstate"
 
 // Source is a source Terraform resource.
 type Source struct {

--- a/tfmigrator/tfstate/read.go
+++ b/tfmigrator/tfstate/read.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Songmu/timeout"
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/log"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/log"
 )
 
 // Reader reads Terraform State.

--- a/tfmigrator/tfstate/update.go
+++ b/tfmigrator/tfstate/update.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Songmu/timeout"
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator/log"
+	"github.com/tfmigrator/tfmigrator/tfmigrator/log"
 )
 
 // Updater updates Terraform State by `terraform state` commands.

--- a/tfmigrator/validate_test.go
+++ b/tfmigrator/validate_test.go
@@ -3,7 +3,7 @@ package tfmigrator_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/tfmigrator/tfmigrator"
+	"github.com/tfmigrator/tfmigrator/tfmigrator"
 )
 
 func TestValidateResourceName(t *testing.T) {


### PR DESCRIPTION
We planned to publish this package as `suzuki-shunsuke/tfmigrator`.
But the the old package is cached in proxy.golang.org, so it is difficult to publish the new package as `suzuki-shunsuke/tfmigrator`.
So we decided to transfer this repository from suzuki-shunsuke to tfmigrator organization.