### PR TITLE
fix: read State by command

### DIFF
--- a/tfmigrator/migrate.go
+++ b/tfmigrator/migrate.go
@@ -98,40 +98,41 @@ func (runner *Runner) MigrateTF(src *Source, migratedResource *MigratedResource)
 
 	if src.Address() != migratedResource.Address && migratedResource.Address != "" { //nolint:nestif
 		// address is changed and isn't empty
-		if src.TFFilePath != migratedResource.TFFilePath() {
-			// Terraform Configuration file path is changed.
-			buf := &bytes.Buffer{}
-			if err := client.GetBlock(src.TFFilePath, "resource."+src.Address(), buf); err != nil {
-				return err //nolint:wrapcheck
-			}
-
-			if err := runner.mkdirAll(filepath.Dir(tfFilePath)); err != nil {
-				return fmt.Errorf("create parent directories of Terraform Configuration file %s: %w", tfFilePath, err)
-			}
-			tfFile, err := runner.appendFile(tfFilePath)
-			if err != nil {
-				return fmt.Errorf("open a file which will write Terraform configuration %s: %w", tfFilePath, err)
-			}
-			defer tfFile.Close()
-
-			if err := client.MoveBlock(&hcledit.MoveBlockOpt{
+		if src.TFFilePath == migratedResource.TFFilePath() || migratedResource.TFFilePath() == "" {
+			// Terraform Configuration file path isn't changed.
+			return client.MoveBlock(&hcledit.MoveBlockOpt{ //nolint:wrapcheck
 				From:     "resource." + src.Address(),
 				To:       "resource." + migratedResource.Address,
-				FilePath: "-",
-				Stdin:    buf,
-				Stdout:   tfFile,
-			}); err != nil {
-				return err //nolint:wrapcheck
-			}
-			return client.RemoveBlock(src.TFFilePath, "resource."+src.Address()) //nolint:wrapcheck
+				Update:   true,
+				FilePath: migratedResource.TFFilePath(),
+				Stdout:   runner.Stdout,
+			})
 		}
-		return client.MoveBlock(&hcledit.MoveBlockOpt{ //nolint:wrapcheck
+		// Terraform Configuration file path is changed.
+		buf := &bytes.Buffer{}
+		if err := client.GetBlock(src.TFFilePath, "resource."+src.Address(), buf); err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		if err := runner.mkdirAll(filepath.Dir(tfFilePath)); err != nil {
+			return fmt.Errorf("create parent directories of Terraform Configuration file %s: %w", tfFilePath, err)
+		}
+		tfFile, err := runner.appendFile(tfFilePath)
+		if err != nil {
+			return fmt.Errorf("open a file which will write Terraform configuration %s: %w", tfFilePath, err)
+		}
+		defer tfFile.Close()
+
+		if err := client.MoveBlock(&hcledit.MoveBlockOpt{
 			From:     "resource." + src.Address(),
 			To:       "resource." + migratedResource.Address,
-			Update:   true,
-			FilePath: migratedResource.TFFilePath(),
-			Stdout:   runner.Stdout,
-		})
+			FilePath: "-",
+			Stdin:    buf,
+			Stdout:   tfFile,
+		}); err != nil {
+			return err //nolint:wrapcheck
+		}
+		return client.RemoveBlock(src.TFFilePath, "resource."+src.Address()) //nolint:wrapcheck
 	}
 
 	if err := runner.mkdirAll(filepath.Dir(tfFilePath)); err != nil {

--- a/tfmigrator/quick_run.go
+++ b/tfmigrator/quick_run.go
@@ -23,9 +23,11 @@ func quickRun(ctx context.Context, planner Planner) error {
 	var dryRun bool
 	var help bool
 	var logLevel string
+	var statePath string
 	flag.BoolVar(&dryRun, "dry-run", false, "dry run")
 	flag.BoolVar(&help, "help", false, "show help message")
 	flag.StringVar(&logLevel, "log-level", "info", "log level")
+	flag.StringVar(&statePath, "state", "", "source State file path")
 	flag.Parse()
 	args := flag.Args()
 
@@ -34,7 +36,7 @@ func quickRun(ctx context.Context, planner Planner) error {
 
 Usage
   tfmigrator help
-  tfmigrator [-help] [-dry-run] [-log-level debug] [Terraform Configuration file path ...]
+  tfmigrator [-help] [-dry-run] [-log-level debug] [-state ""] [Terraform Configuration file path ...]
 
 Example
 
@@ -61,5 +63,6 @@ Example
 
 	return runner.Run(ctx, &RunOpt{
 		SourceTFFilePaths: args,
+		SourceStatePath:   statePath,
 	})
 }

--- a/tfmigrator/runner.go
+++ b/tfmigrator/runner.go
@@ -125,15 +125,8 @@ func (runner *Runner) Run(ctx context.Context, opt *RunOpt) error {
 }
 
 func (runner *Runner) readState(ctx context.Context, sourceStatePath string, state *tfstate.State) error {
-	if sourceStatePath == "" {
-		// read state by command
-		if err := runner.StateReader.ReadByCmd(ctx, state); err != nil {
-			return fmt.Errorf("read Terraform State by command: %w", err)
-		}
-	} else {
-		if err := tfstate.ReadFromFile(sourceStatePath, state); err != nil {
-			return fmt.Errorf("read Terraform State from a file %s: %w", sourceStatePath, err)
-		}
+	if err := runner.StateReader.ReadByCmd(ctx, sourceStatePath, state); err != nil {
+		return fmt.Errorf("read Terraform State by command: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
* fix: read State by command

The State file content is different from the output of `terraform show -json`.
We decide to read State by `terraform show -json`.

* feat: add `-state` option to QuickRun to specify source State file path
* fix: fix the check if the Terraform Configuration file path is changed

## BREAKING CHANGE:

* The method `tfstate.Reader#ReadFromFile` is removed
  * Use `tfstate.Reader.ReadByCmd` instead
* The signature of `tfstate.Reader.ReadByCmd` is changed
  * The argument `filePath` is added