### PR TITLE
feat: complement HCLFileBasename and StateBasename

### DIFF
--- a/tfmigrator/result.go
+++ b/tfmigrator/result.go
@@ -33,6 +33,9 @@ type MigratedResource struct {
 
 // StatePath returns a file path to Terraform State file.
 func (rsc *MigratedResource) StatePath() string {
+	if rsc.Dirname != "" && rsc.StateBasename == "" {
+		return filepath.Join(rsc.Dirname, "terraform.tfstate")
+	}
 	return filepath.Join(rsc.Dirname, rsc.StateBasename)
 }
 


### PR DESCRIPTION
* If `MigratedResource.Dir` isn't empty but `MigratedResource.StateBasename` is empty, `terraform.tfstate` is used as state basename.
* If `MigratedResource.Dir` isn't empty but `MigratedResource.HCLFileBasename` is empty, `filepath.Base(src.HCLFilePath)` is used as HCL File basename.