### PR TITLE
fix: ignore resource addresses which doesn't start with "resource." or "module."

### DIFF
--- a/tfmigrator/hcledit/list.go
+++ b/tfmigrator/hcledit/list.go
@@ -37,6 +37,9 @@ func (client *Client) ListBlockMap(filePath string) (map[string]struct{}, error)
 		if line == "" {
 			continue
 		}
+		if !strings.HasPrefix(line, "resource.") && !strings.HasPrefix(line, "module.") {
+			continue
+		}
 		if _, ok := m[line]; ok {
 			return nil, errors.New("resource address is duplicated: " + line)
 		}


### PR DESCRIPTION
When multiple `locals` blocks are defined, the following error occurs.

```
2021/06/20 09:53:53 list all addresses in Terraform Configuration files: resource address (locals) is duplicated: users.tf and variables.tf
```